### PR TITLE
Add option to add requirements to the Python path

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,8 +16,11 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
       - run: |
+          python -m venv .venv
+      - run: |
+          source .venv/bin/activate
           pip install -r requirements.txt --no-deps --only-binary=:all:
       - run: |
+          source .venv/bin/activate
           pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+- Feat: Add an option to append vendor package to the Python Path
+- Feat: Add an option to bundle requirements of the requirements recursively
+- Feat: Add module packages and .pyd files to the bundle if found
+- Chore: Drop support from Python < 3.9
+
 ## [0.2.1] - 2022-07-07
 
 - Fix: Correct some plain import rewrites

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ runtime_requires = [
 ]
 ```
 
+If the plugin runtime dependencies do not work with the aforementioned configuration, the dependencies can be added to the Python Path with `use_dangerous_vendor_sys_path_append` flag. This method might be **unsafe** if there are conflicts between dependency versions of different plugins.
+
+```toml
+[tool.qgis_plugin_dev_tools]
+plugin_package_name = "your_plugin_package_name"
+runtime_requires = [
+    "some_pypi_package_with_binary_files"
+]
+use_dangerous_vendor_sys_path_append = true
+```
+
 ## Plugin packaging
 
 Run `qgis-plugin-dev-tools build` (short `qpdt b`) to package the plugin and any runtime dependencies to a standard QGIS plugin zip file, that can be installed and published.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ runtime_requires = [
 ]
 ```
 
+If the plugin runtime dependencies have many dependencies themselves, it is possible to include those recursively with `auto_add_recursive_runtime_dependencies`. Alternatively, all the requirements can be listed in `runtime_requires`.
+
+```toml
+[tool.qgis_plugin_dev_tools]
+plugin_package_name = "your_plugin_package_name"
+runtime_requires = [
+    "some_pypi_package"
+]
+auto_add_recursive_runtime_dependencies = true
+```
+
 If the plugin runtime dependencies do not work with the aforementioned configuration, the dependencies can be added to the Python Path with `use_dangerous_vendor_sys_path_append` flag. This method might be **unsafe** if there are conflicts between dependency versions of different plugins.
 
 ```toml

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ classifiers =
     License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3 :: Only
@@ -30,7 +28,7 @@ keywords =
     qgis
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.9
 packages = find:
 package_dir =
     = src

--- a/src/qgis_plugin_dev_tools/build/packaging.py
+++ b/src/qgis_plugin_dev_tools/build/packaging.py
@@ -73,12 +73,19 @@ def copy_runtime_requirements(
 
     runtime_package_names = []
     # copy dist infos (licenses etc.) and all provided top level packages
-    for dist in dev_tools_config.runtime_distributions:
+    for dist in (
+        dev_tools_config.runtime_distributions
+        + dev_tools_config.extra_runtime_distributions
+    ):
         dist_info_path = Path(dist._path)  # type: ignore
-        if Path(sys.base_prefix) in dist_info_path.parent.parents:
+        if (
+            Path(sys.base_prefix) in dist_info_path.parent.parents
+            and dist in dev_tools_config.extra_runtime_distributions
+        ):
             # If QGIS Python includes the dependency, it does not have to be bundled
             LOGGER.debug(
-                "skipping runtime requirement %s because it is included in QGIS",
+                "skipping recursively found runtime requirement %s "
+                "because it is included in QGIS",
                 dist.metadata["Name"],
             )
             continue

--- a/src/qgis_plugin_dev_tools/build/rewrite_imports.py
+++ b/src/qgis_plugin_dev_tools/build/rewrite_imports.py
@@ -116,3 +116,9 @@ def rewrite_imports_in_source_file(
     )
 
     source_file.write_text(contents, encoding="utf-8")
+
+
+def insert_as_first_import(plugin_init_file: Path, import_string: str) -> None:
+    contents = plugin_init_file.read_text(encoding="utf-8")
+    contents = f"import {import_string}\n" + contents
+    plugin_init_file.write_text(contents, encoding="utf-8")

--- a/src/qgis_plugin_dev_tools/config/__init__.py
+++ b/src/qgis_plugin_dev_tools/config/__init__.py
@@ -31,12 +31,14 @@ class DevToolsConfig:
     plugin_package_path: Path
     runtime_distributions: List[Distribution]
     changelog_file_path: Path
+    append_distributions_to_path: bool
 
     def __init__(
         self,
         plugin_package_name: str,
         runtime_requires: List[str],
         changelog_file_path: Path,
+        append_distributions_to_path: bool,
     ) -> None:
         self.plugin_package_name = plugin_package_name
         self.plugin_package_path = Path(
@@ -47,6 +49,7 @@ class DevToolsConfig:
             distribution(Requirement(spec).name) for spec in runtime_requires
         ]
         self.changelog_file_path = changelog_file_path
+        self.append_distributions_to_path = append_distributions_to_path
 
     @staticmethod
     def from_pyproject_config(pyproject_file_path: Path) -> "DevToolsConfig":
@@ -56,4 +59,7 @@ class DevToolsConfig:
             runtime_requires=pyproject_config.runtime_requires,
             # TODO: allow setting path in pyproject file?
             changelog_file_path=pyproject_file_path.parent / "CHANGELOG.md",
+            append_distributions_to_path=(
+                pyproject_config.use_dangerous_vendor_sys_path_append
+            ),
         )

--- a/src/qgis_plugin_dev_tools/config/__init__.py
+++ b/src/qgis_plugin_dev_tools/config/__init__.py
@@ -53,12 +53,12 @@ class DevToolsConfig:
         ]
         self.changelog_file_path = changelog_file_path
         self.append_distributions_to_path = append_distributions_to_path
+        self.extra_runtime_distributions = []
 
         if auto_add_recursive_runtime_dependencies:
             # Add the requirements of the distributions as well
-            self.runtime_distributions = list(
+            self.extra_runtime_distributions = list(
                 ChainMap(
-                    {dist.name: dist for dist in self.runtime_distributions},
                     *(
                         get_distribution_requirements(dist)
                         for dist in self.runtime_distributions

--- a/src/qgis_plugin_dev_tools/config/__init__.py
+++ b/src/qgis_plugin_dev_tools/config/__init__.py
@@ -17,6 +17,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with qgis-plugin-dev-tools. If not, see <https://www.gnu.org/licenses/>.
 
+from collections import ChainMap
 from pathlib import Path
 from typing import List
 
@@ -24,6 +25,7 @@ from importlib_metadata import Distribution, distribution
 from packaging.requirements import Requirement
 
 from qgis_plugin_dev_tools.config.pyproject import read_pyproject_config
+from qgis_plugin_dev_tools.utils.distributions import get_distribution_requirements
 
 
 class DevToolsConfig:
@@ -50,6 +52,18 @@ class DevToolsConfig:
         ]
         self.changelog_file_path = changelog_file_path
         self.append_distributions_to_path = append_distributions_to_path
+
+        if append_distributions_to_path:
+            # Add the requirements of the distributions as well
+            self.runtime_distributions = list(
+                ChainMap(
+                    {dist.name: dist for dist in self.runtime_distributions},
+                    *(
+                        get_distribution_requirements(dist)
+                        for dist in self.runtime_distributions
+                    )
+                ).values()
+            )
 
     @staticmethod
     def from_pyproject_config(pyproject_file_path: Path) -> "DevToolsConfig":

--- a/src/qgis_plugin_dev_tools/config/__init__.py
+++ b/src/qgis_plugin_dev_tools/config/__init__.py
@@ -41,6 +41,7 @@ class DevToolsConfig:
         runtime_requires: List[str],
         changelog_file_path: Path,
         append_distributions_to_path: bool,
+        auto_add_recursive_runtime_dependencies: bool,
     ) -> None:
         self.plugin_package_name = plugin_package_name
         self.plugin_package_path = Path(
@@ -53,7 +54,7 @@ class DevToolsConfig:
         self.changelog_file_path = changelog_file_path
         self.append_distributions_to_path = append_distributions_to_path
 
-        if append_distributions_to_path:
+        if auto_add_recursive_runtime_dependencies:
             # Add the requirements of the distributions as well
             self.runtime_distributions = list(
                 ChainMap(
@@ -75,5 +76,8 @@ class DevToolsConfig:
             changelog_file_path=pyproject_file_path.parent / "CHANGELOG.md",
             append_distributions_to_path=(
                 pyproject_config.use_dangerous_vendor_sys_path_append
+            ),
+            auto_add_recursive_runtime_dependencies=(
+                pyproject_config.auto_add_recursive_runtime_dependencies
             ),
         )

--- a/src/qgis_plugin_dev_tools/config/pyproject.py
+++ b/src/qgis_plugin_dev_tools/config/pyproject.py
@@ -38,6 +38,7 @@ class PyprojectConfig:
     plugin_package_name: str
     runtime_requires: List[str] = field(default_factory=list)
     use_dangerous_vendor_sys_path_append: bool = False
+    auto_add_recursive_runtime_dependencies: bool = False
 
 
 def read_pyproject_config(pyproject_file_path: Path) -> PyprojectConfig:

--- a/src/qgis_plugin_dev_tools/config/pyproject.py
+++ b/src/qgis_plugin_dev_tools/config/pyproject.py
@@ -37,6 +37,7 @@ class PyprojectConfig:
 
     plugin_package_name: str
     runtime_requires: List[str] = field(default_factory=list)
+    use_dangerous_vendor_sys_path_append: bool = False
 
 
 def read_pyproject_config(pyproject_file_path: Path) -> PyprojectConfig:

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,0 +1,134 @@
+import os
+import sys
+import textwrap
+import zipfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Set
+
+import pytest
+
+from qgis_plugin_dev_tools.build import make_plugin_zip
+
+if TYPE_CHECKING:
+    from qgis_plugin_dev_tools.config import DevToolsConfig
+
+
+@pytest.fixture()
+def plugin_dir(tmp_path: Path) -> Path:
+    plugin_dir = tmp_path / "Plugin"
+    plugin_dir.mkdir()
+
+    changelog_file = plugin_dir / "CHANGELOG.md"
+    changelog_file.write_text(
+        textwrap.dedent(
+            """\
+    # CHANGELOG
+
+    ## 0.1.0 - First release
+
+    - new feature
+    """
+        )
+    )
+
+    metadata_file = plugin_dir / "metadata.txt"
+    metadata_file.write_text(
+        textwrap.dedent(
+            """\
+    [general]
+    name=Plugin
+    description=
+    about=
+    version=0.0.1
+    author=
+    email=
+    changelog=
+    tags=
+    category=Plugins
+    experimental=True
+    deprecated=False"""
+        )
+    )
+
+    main_file = plugin_dir / "__init__.py"
+    main_file.touch()
+
+    os.chdir(tmp_path.resolve())
+    sys.path.append(tmp_path.resolve().as_posix())
+
+    return plugin_dir
+
+
+@pytest.fixture()
+def dev_tools_config(plugin_dir: Path):
+    from qgis_plugin_dev_tools.config import DevToolsConfig
+
+    return DevToolsConfig(
+        plugin_package_name="Plugin",
+        runtime_requires=["pytest"],
+        changelog_file_path=plugin_dir / "CHANGELOG.md",
+        append_distributions_to_path=(True),
+    )
+
+
+def test_make_zip(dev_tools_config: "DevToolsConfig", plugin_dir: Path, tmp_path: Path):
+    target_path = tmp_path / "dist"
+    expected_zip = target_path / "Plugin-0.1.0.zip"
+
+    make_plugin_zip(dev_tools_config, target_path)
+
+    assert target_path.exists()
+    assert expected_zip.exists()
+
+    plugin_init_file_contents = _get_file_from_zip(expected_zip, "Plugin/__init__.py")
+    vendor_init_file_contents = _get_file_from_zip(
+        expected_zip, "Plugin/_vendor/__init__.py"
+    )
+    vendor_files = _get_file_names(expected_zip, "Plugin/_vendor/")
+
+    assert "import Plugin._vendor" in plugin_init_file_contents
+    assert "sys.path.append" in vendor_init_file_contents
+    assert vendor_files == {
+        "__init__.py",
+        "_pytest",
+        "atomicwrites",
+        "atomicwrites-1.4.0.dist-info",
+        "attr",
+        "attrs",
+        "attrs-21.4.0.dist-info",
+        "colorama",
+        "colorama-0.4.4.dist-info",
+        "importlib_metadata",
+        "importlib_metadata-4.11.3.dist-info",
+        "iniconfig",
+        "iniconfig-1.1.1.dist-info",
+        "packaging",
+        "packaging-21.3.dist-info",
+        "pluggy",
+        "pluggy-1.0.0.dist-info",
+        "py",
+        "py-1.11.0.dist-info",
+        "pyparsing-3.0.8.dist-info",
+        "pytest",
+        "pytest-6.2.5.dist-info",
+        "toml",
+        "toml-0.10.2.dist-info",
+        "typing_extensions-4.2.0.dist-info",
+        "zipp-3.8.0.dist-info",
+        "zipp.py",
+    }
+
+
+def _get_file_names(zip_file: Path, prefix: str) -> Set[str]:
+    with zipfile.ZipFile(zip_file) as z:
+        namelist = z.namelist()
+        return {
+            name.replace(prefix, "").split("/")[0]
+            for name in namelist
+            if name.startswith(prefix) and name != prefix
+        }
+
+
+def _get_file_from_zip(zip_file: Path, file_path: str) -> str:
+    f = zipfile.Path(zip_file, at=file_path)
+    return f.read_text()

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -67,7 +67,7 @@ def dev_tools_config(plugin_dir: Path):
         plugin_package_name="Plugin",
         runtime_requires=["pytest"],
         changelog_file_path=plugin_dir / "CHANGELOG.md",
-        append_distributions_to_path=(True),
+        append_distributions_to_path=True,
     )
 
 
@@ -130,5 +130,5 @@ def _get_file_names(zip_file: Path, prefix: str) -> Set[str]:
 
 
 def _get_file_from_zip(zip_file: Path, file_path: str) -> str:
-    f = zipfile.Path(zip_file, at=file_path)
-    return f.read_text()
+    with zipfile.ZipFile(zip_file) as z, z.open(file_path) as f:
+        return f.read().decode("UTF-8")

--- a/test/test_read_distributions.py
+++ b/test/test_read_distributions.py
@@ -1,0 +1,28 @@
+import pytest
+from importlib_metadata import distribution
+from packaging.requirements import Requirement
+
+from qgis_plugin_dev_tools.utils.distributions import get_distribution_requirements
+
+
+@pytest.fixture()
+def sample_dist():
+    return distribution(Requirement("pytest").name)
+
+
+def test_get_distribution_requirements(sample_dist):
+    requirements = get_distribution_requirements(sample_dist)
+    assert sorted(requirements.keys()) == [
+        "atomicwrites",
+        "attrs",
+        "colorama",
+        "importlib-metadata",
+        "iniconfig",
+        "packaging",
+        "pluggy",
+        "py",
+        "pyparsing",
+        "toml",
+        "typing-extensions",
+        "zipp",
+    ]

--- a/test/test_read_pyproject.py
+++ b/test/test_read_pyproject.py
@@ -64,6 +64,7 @@ def test_requires_allowed_empty(create_pyproject_toml_with_contents):
     result = read_pyproject_config(test_file)
     assert result.runtime_requires == []
     assert not result.use_dangerous_vendor_sys_path_append
+    assert not result.auto_add_recursive_runtime_dependencies
 
 
 def test_section_read_to_dataclass(create_pyproject_toml_with_contents):
@@ -73,6 +74,7 @@ def test_section_read_to_dataclass(create_pyproject_toml_with_contents):
             'plugin_package_name = "testing"',
             'runtime_requires = ["one", "another"]',
             "use_dangerous_vendor_sys_path_append = true",
+            "auto_add_recursive_runtime_dependencies = true",
         ]
     )
 
@@ -81,3 +83,4 @@ def test_section_read_to_dataclass(create_pyproject_toml_with_contents):
     assert result.plugin_package_name == "testing"
     assert result.runtime_requires == ["one", "another"]
     assert result.use_dangerous_vendor_sys_path_append
+    assert result.auto_add_recursive_runtime_dependencies

--- a/test/test_read_pyproject.py
+++ b/test/test_read_pyproject.py
@@ -61,7 +61,9 @@ def test_requires_allowed_empty(create_pyproject_toml_with_contents):
         ]
     )
 
-    assert read_pyproject_config(test_file).runtime_requires == []
+    result = read_pyproject_config(test_file)
+    assert result.runtime_requires == []
+    assert not result.use_dangerous_vendor_sys_path_append
 
 
 def test_section_read_to_dataclass(create_pyproject_toml_with_contents):
@@ -70,6 +72,7 @@ def test_section_read_to_dataclass(create_pyproject_toml_with_contents):
             "[tool.qgis_plugin_dev_tools]",
             'plugin_package_name = "testing"',
             'runtime_requires = ["one", "another"]',
+            "use_dangerous_vendor_sys_path_append = true",
         ]
     )
 
@@ -77,3 +80,4 @@ def test_section_read_to_dataclass(create_pyproject_toml_with_contents):
 
     assert result.plugin_package_name == "testing"
     assert result.runtime_requires == ["one", "another"]
+    assert result.use_dangerous_vendor_sys_path_append

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -29,3 +29,4 @@ configs
 dest
 metavar
 util
+pyd


### PR DESCRIPTION
This PR:
- Introduces new toml option `use_dangerous_vendor_sys_path_append` that causes the whole _vendor package to be added to Python path
- Introduces new toml option `auto_add_recursive_runtime_dependencies` that searches requirements recursively from the given requirement and bundles those as well 
- Includes module requirements and pyd files as well
- Drops support from Python < 3.9, since[`ast.unparse`](https://docs.python.org/3/library/ast.html?#ast.unparse) used in import rewriting was introduced in Python 3.9