### PR TITLE
Version argument to build cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Feat: Add an option to append vendor package to the Python Path
 - Feat: Add an option to bundle requirements of the requirements recursively
 - Feat: Add module packages and .pyd files to the bundle if found
+- Feat: Add version as an optional build argument
 - Chore: Drop support from Python < 3.9
 
 ## [0.2.1] - 2022-07-07

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ use_dangerous_vendor_sys_path_append = true
 
 Run `qgis-plugin-dev-tools build` (short `qpdt b`) to package the plugin and any runtime dependencies to a standard QGIS plugin zip file, that can be installed and published.
 
-By default config is read from `pyproject.toml`, changelog notes from `CHANGELOG.md`, version from latest changelog item title, and package is created in a `dist` directory in the current working directory. Changelog contents and version number are inserted to the `metadata.txt` file, so the version and changelog sections do not need manual updates.
+By default config is read from `pyproject.toml`, changelog notes from `CHANGELOG.md`, version from latest changelog item title, and package is created in a `dist` directory in the current working directory. Changelog contents and version number are inserted to the `metadata.txt` file, so the version and changelog sections do not need manual updates. Optionally the version number can also be provided as an argument: `qpdt b --version 0.1.0-rc2`.
+
 
 ## Plugin development mode
 

--- a/src/qgis_plugin_dev_tools/build/__init__.py
+++ b/src/qgis_plugin_dev_tools/build/__init__.py
@@ -22,6 +22,7 @@ import os
 import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Optional
 
 from qgis_plugin_dev_tools.build.changelog_parser import (
     get_latest_changelog_sections,
@@ -38,14 +39,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 def make_plugin_zip(
-    dev_tools_config: DevToolsConfig, target_directory_path: Path
+    dev_tools_config: DevToolsConfig,
+    target_directory_path: Path,
+    plugin_version: Optional[str] = None,
 ) -> None:
     # TODO: make setuptools wrapper and use this code when creating the sdist/wheel?
 
     changelog_contents = get_latest_changelog_sections(
         dev_tools_config.changelog_file_path
     )
-    version = get_latest_changelog_version_identifier(
+    version = plugin_version or get_latest_changelog_version_identifier(
         dev_tools_config.changelog_file_path
     )
     zip_name = f"{dev_tools_config.plugin_package_name}-{version}"

--- a/src/qgis_plugin_dev_tools/cli/__init__.py
+++ b/src/qgis_plugin_dev_tools/cli/__init__.py
@@ -21,7 +21,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 from importlib_metadata import entry_points
 
@@ -74,7 +74,7 @@ def start(dotenv_file_paths: List[Path]) -> None:
     )
 
 
-def build() -> None:
+def build(plugin_version: Optional[str]) -> None:
     # TODO: allow choosing pyproject file from cli?
     dev_tools_config = DevToolsConfig.from_pyproject_config(Path("pyproject.toml"))
     LOGGER.info("building plugin package %s", dev_tools_config.plugin_package_name)
@@ -83,7 +83,11 @@ def build() -> None:
         dev_tools_config.plugin_package_path.resolve(),
     )
     # TODO: allow choosing output path from cli?
-    make_plugin_zip(dev_tools_config, target_directory_path=Path("dist"))
+    make_plugin_zip(
+        dev_tools_config,
+        target_directory_path=Path("dist"),
+        plugin_version=plugin_version,
+    )
 
 
 parser = argparse.ArgumentParser(description="QGIS plugin dev tools cli")
@@ -120,6 +124,14 @@ build_parser = commands.add_parser(
     help="build the plugin",
     parents=[common_parser],
 )
+build_parser.add_argument(
+    "--version",
+    metavar="<version>",
+    dest="plugin_version",
+    type=str,
+    default="",
+    help="version of the plugin (leave empty to get the version from the CHANGELOG.md)",
+)
 
 
 def run() -> None:
@@ -136,7 +148,8 @@ def run() -> None:
         start(dotenv_file_paths)
 
     elif result.get("subcommand") in ["build", "b"]:
-        build()
+        plugin_version = str(result.get("plugin_version"))
+        build(plugin_version)
 
     else:
         parser.print_usage()

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -138,9 +138,11 @@ def test_make_zip_with_minimal_config(
     dev_tools_config_minimal: "DevToolsConfig", plugin_dir: Path, tmp_path: Path
 ):
     target_path = tmp_path / "dist"
-    expected_zip = target_path / "Plugin-0.1.0.zip"
+    expected_zip = target_path / "Plugin-test-version.zip"
 
-    make_plugin_zip(dev_tools_config_minimal, target_path)
+    make_plugin_zip(
+        dev_tools_config_minimal, target_path, plugin_version="test-version"
+    )
 
     assert target_path.exists()
     assert expected_zip.exists()


### PR DESCRIPTION
This PR:
- Adds optioanal version argument to build cli. This is used as the version in metadata.txt and plugin zip name. If the argument is missing, the version number is read from the CHANGELOG.md as before.

WIP:
- [x] Wait until #8 is merged and do rebase before merging