### PR TITLE
fix: fix fetching recursive runtime deps

### DIFF
--- a/src/qgis_plugin_dev_tools/config/__init__.py
+++ b/src/qgis_plugin_dev_tools/config/__init__.py
@@ -78,14 +78,19 @@ class DevToolsConfig:
 
         if auto_add_recursive_runtime_dependencies:
             # Add the requirements of the distributions as well
-            self.extra_runtime_distributions = list(
-                ChainMap(
+            distributions_versions = {
+                dist.name: dist.version for dist in self.runtime_distributions
+            }
+            self.extra_runtime_distributions = [
+                dist
+                for dist in ChainMap(
                     *(
                         get_distribution_requirements(dist)
                         for dist in self.runtime_distributions
                     )
                 ).values()
-            )
+                if distributions_versions.get(dist.name) != dist.version
+            ]
 
     @staticmethod
     def from_pyproject_config(pyproject_file_path: Path) -> "DevToolsConfig":

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -73,6 +73,19 @@ def dev_tools_config(plugin_dir: Path):
 
 
 @pytest.fixture()
+def dev_tools_config_with_duplicate_dependencies(plugin_dir: Path):
+    from qgis_plugin_dev_tools.config import DevToolsConfig
+
+    return DevToolsConfig(
+        plugin_package_name="Plugin",
+        runtime_requires=["pytest-cov"],
+        changelog_file_path=plugin_dir / "CHANGELOG.md",
+        append_distributions_to_path=True,
+        auto_add_recursive_runtime_dependencies=True,
+    )
+
+
+@pytest.fixture()
 def dev_tools_config_minimal(plugin_dir: Path):
     # No python path append and not recursive deps
     from qgis_plugin_dev_tools.config import DevToolsConfig
@@ -126,6 +139,62 @@ def test_make_zip(dev_tools_config: "DevToolsConfig", plugin_dir: Path, tmp_path
         "pyparsing-3.0.8.dist-info",
         "pytest",
         "pytest-6.2.5.dist-info",
+        "toml",
+        "toml-0.10.2.dist-info",
+        "typing_extensions-4.2.0.dist-info",
+        "zipp-3.8.0.dist-info",
+        "zipp.py",
+    }
+
+
+def test_make_zip_with_duplicate_dependencies(
+    dev_tools_config_with_duplicate_dependencies: "DevToolsConfig",
+    plugin_dir: Path,
+    tmp_path: Path,
+):
+    target_path = tmp_path / "dist"
+    expected_zip = target_path / "Plugin-0.1.0.zip"
+
+    make_plugin_zip(dev_tools_config_with_duplicate_dependencies, target_path)
+
+    assert target_path.exists()
+    assert expected_zip.exists()
+
+    plugin_init_file_contents = _get_file_from_zip(expected_zip, "Plugin/__init__.py")
+    vendor_init_file_contents = _get_file_from_zip(
+        expected_zip, "Plugin/_vendor/__init__.py"
+    )
+    vendor_files = _get_file_names(expected_zip, "Plugin/_vendor/")
+
+    assert "import Plugin._vendor" in plugin_init_file_contents
+    assert "sys.path.append" in vendor_init_file_contents
+    assert vendor_files == {
+        "__init__.py",
+        "_pytest",
+        "atomicwrites",
+        "atomicwrites-1.4.0.dist-info",
+        "attr",
+        "attrs",
+        "attrs-21.4.0.dist-info",
+        "colorama",
+        "colorama-0.4.4.dist-info",
+        "coverage",
+        "coverage-6.3.2.dist-info",
+        "importlib_metadata",
+        "importlib_metadata-4.11.3.dist-info",
+        "iniconfig",
+        "iniconfig-1.1.1.dist-info",
+        "packaging",
+        "packaging-21.3.dist-info",
+        "pluggy",
+        "pluggy-1.0.0.dist-info",
+        "py",
+        "py-1.11.0.dist-info",
+        "pyparsing-3.0.8.dist-info",
+        "pytest",
+        "pytest-6.2.5.dist-info",
+        "pytest_cov",
+        "pytest_cov-2.12.0.dist-info",
         "toml",
         "toml-0.10.2.dist-info",
         "typing_extensions-4.2.0.dist-info",


### PR DESCRIPTION
This PR fixes few issues with fetching recursive runtime dependencies:
- Build crashed if some builtin package is used as a requirements
- Build crashed if some dependency was in both runtime_distributions and extra_runtime_distributions