### PR TITLE
feat: copy license to plugin zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ plugin_package_name = "your_plugin_package_name"
 version_number_source = "distribution"  # or "changelog" (default if missing)
 ```
 
+QGIS plugins are required to have a LICENSE file included in the plugin package. However, usually it is more convenient to keep the license file in the root of the repository. LICENSE can be copied automatically to the plugin zip while packaging if such file is found. A relative path to the license file can also be configured with `license_file_path` option.
+
+```toml
+[tool.qgis_plugin_dev_tools]
+plugin_package_name = "your_plugin_package_name"
+license_file_path = "docs/my-license.md"
+```
+
 ## Plugin packaging
 
 Run `qgis-plugin-dev-tools build` (short `qpdt b`) to package the plugin and any runtime dependencies to a standard QGIS plugin zip file, that can be installed and published.

--- a/src/qgis_plugin_dev_tools/build/__init__.py
+++ b/src/qgis_plugin_dev_tools/build/__init__.py
@@ -35,6 +35,7 @@ from qgis_plugin_dev_tools.build.metadata import update_metadata_file
 from qgis_plugin_dev_tools.build.packaging import (
     copy_plugin_code,
     copy_runtime_requirements,
+    copy_license,
 )
 from qgis_plugin_dev_tools.config import DevToolsConfig, VersionNumberSource
 
@@ -84,6 +85,7 @@ def make_plugin_zip(
             changelog_contents,
         )
         copy_runtime_requirements(dev_tools_config, build_directory_path)
+        copy_license(dev_tools_config, build_directory_path)
 
         LOGGER.debug("creating built plugin zip file from build directory")
 

--- a/src/qgis_plugin_dev_tools/config/pyproject.py
+++ b/src/qgis_plugin_dev_tools/config/pyproject.py
@@ -20,7 +20,7 @@
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 import tomli
 
@@ -43,6 +43,7 @@ class PyprojectConfig:
         Literal["changelog"], Literal["distribution"]
     ] = "changelog"
     disabled_extra_plugins: list[str] = field(default_factory=list)
+    license_file_path: Optional[str] = None
 
     def __post_init__(self) -> None:
         if self.version_number_source not in ["changelog", "distribution"]:


### PR DESCRIPTION
QGIS plugin repository [validates](https://github.com/qgis/QGIS-Django/blob/77322304aa7f0965e024d9346ef8a51ec4fa0677/qgis-app/plugins/validator.py#L364) that a file `package_name + "/LICENSE"` exists.

This PR:

- Copies LICENSE file to the plugin directory of the zip when deploying
