### PR TITLE
Start debugger before enabling plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+- Fix: start debugger before enabling plugin
+
 ## [0.12.0] - 2026-03-19
 
 - Feat: add normalize xml hook

--- a/src/qgis_plugin_dev_tools/start/bootstrap/template.py
+++ b/src/qgis_plugin_dev_tools/start/bootstrap/template.py
@@ -311,13 +311,13 @@ def _do_bootstrap(config: BootstrapConfig) -> None:
         _enable_extra_plugins(
             config.plugin_package_name, config.extra_plugin_package_names
         )
+        _start_debugger(
+            config.debugger_library, config.bootstrap_python_executable_path
+        )
         _enable_plugin(
             config.plugin_package_name,
             config.plugin_package_path,
             config.plugin_dependency_package_names,
-        )
-        _start_debugger(
-            config.debugger_library, config.bootstrap_python_executable_path
         )
 
     def _on_socket_error(error_type: QAbstractSocket.SocketError) -> None:


### PR DESCRIPTION
This PR fixes annoying problem when starting the debugger: the debugger starts after initGui has already been executed.

